### PR TITLE
#25570 : Redis / Session-less testing and improvements

### DIFF
--- a/src/main/java/com/dotcms/tomcat/redissessions/JavaSerializer.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/JavaSerializer.java
@@ -1,5 +1,9 @@
 package com.dotcms.tomcat.redissessions;
 
+import org.apache.catalina.util.CustomObjectInputStream;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -11,68 +15,67 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Enumeration;
 import java.util.HashMap;
-import org.apache.catalina.util.CustomObjectInputStream;
-import org.apache.juli.logging.Log;
-import org.apache.juli.logging.LogFactory;
 
+/**
+ * Implementation class for the {@link Serializer} interface. This implementation uses the default Java serialization
+ * mechanism. The Class Loader used by this deserializer is retrieved from the current context provided by the
+ * {@link org.apache.catalina.session.ManagerBase} class.
+ */
 public class JavaSerializer implements Serializer {
     private ClassLoader loader;
 
     private final Log log = LogFactory.getLog(JavaSerializer.class);
 
     @Override
-    public void setClassLoader(ClassLoader loader) {
+    public void setClassLoader(final ClassLoader loader) {
         this.loader = loader;
     }
 
-    public byte[] attributesHashFrom(RedisSession session) throws IOException {
-        HashMap<String, Object> attributes = new HashMap<String, Object>();
-        for (Enumeration<String> enumerator = session.getAttributeNames(); enumerator.hasMoreElements();) {
-            String key = enumerator.nextElement();
+    @Override
+    public byte[] attributesHashFrom(final RedisSession session) throws IOException {
+        final HashMap<String, Object> attributes = new HashMap<>();
+        for (final Enumeration<String> enumerator = session.getAttributeNames(); enumerator.hasMoreElements();) {
+            final String key = enumerator.nextElement();
             attributes.put(key, session.getAttribute(key));
         }
-
-        byte[] serialized = null;
-
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                        ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(bos));) {
+        byte[] serialized;
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             final ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(bos))) {
             oos.writeUnshared(attributes);
             oos.flush();
             serialized = bos.toByteArray();
         }
-
         MessageDigest digester = null;
         try {
             digester = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            log.error("Unable to get MessageDigest instance for MD5");
+        } catch (final NoSuchAlgorithmException e) {
+            log.error("Unable to get MessageDigest instance for MD5 for session ID " + session.getId());
         }
         return digester.digest(serialized);
     }
 
     @Override
-    public byte[] serializeFrom(RedisSession session, SessionSerializationMetadata metadata) throws IOException {
-        byte[] serialized = null;
-
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                        ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(bos));) {
+    public byte[] serializeFrom(final RedisSession session, final SessionSerializationMetadata metadata) throws IOException {
+        byte[] serialized;
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             final ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(bos))) {
             oos.writeObject(metadata);
             session.writeObjectData(oos);
             oos.flush();
             serialized = bos.toByteArray();
         }
-
         return serialized;
     }
 
     @Override
-    public void deserializeInto(byte[] data, RedisSession session, SessionSerializationMetadata metadata)
+    public void deserializeInto(final byte[] data, final RedisSession session, final SessionSerializationMetadata metadata)
                     throws IOException, ClassNotFoundException {
-        try (BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(data));
-                        ObjectInputStream ois = new CustomObjectInputStream(bis, loader);) {
-            SessionSerializationMetadata serializedMetadata = (SessionSerializationMetadata) ois.readObject();
+        try (final BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(data));
+             final ObjectInputStream ois = new CustomObjectInputStream(bis, loader)) {
+            final SessionSerializationMetadata serializedMetadata = (SessionSerializationMetadata) ois.readObject();
             metadata.copyFieldsFrom(serializedMetadata);
             session.readObjectData(ois);
         }
     }
+
 }

--- a/src/main/java/com/dotcms/tomcat/redissessions/RedisSession.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/RedisSession.java
@@ -129,7 +129,6 @@ public class RedisSession extends StandardSession {
                 log.warn(String.format("Value of key '%s' is not serializable. Removing it from Session '%s'", key,
                         this.id));
             }
-            super.removeAttribute(key);
         }
         if ((value != null || oldValue != null)
                 && (value == null && oldValue != null

--- a/src/main/java/com/dotcms/tomcat/redissessions/RedisSession.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/RedisSession.java
@@ -24,53 +24,118 @@ public class RedisSession extends StandardSession {
 
     protected static boolean manualDirtyTrackingSupportEnabled = false;
 
-    public static void setManualDirtyTrackingSupportEnabled(boolean enabled) {
+    /**
+     * Activates a feature in the Redis-enabled Session Manager that allows developers to send a specific attribute to
+     * indicate the plugin that the Session must be saved, no matter what. You can customize the attribute's name via
+     * the {@link #setManualDirtyTrackingAttributeKey(String)} method.
+     * <p>If you have a {@link java.util.List} as your attribute, and you add or remove elements to it, the plugin will
+     * not be able to detect that change. Using the manual dirty tracking allows you to force the plugin to save the
+     * session instead of letting it make the choice.</p>
+     *
+     * @param enabled If {@code true}, developers will be able to ask the plugin to force saving a session.
+     */
+    public static void setManualDirtyTrackingSupportEnabled(final boolean enabled) {
         manualDirtyTrackingSupportEnabled = enabled;
     }
 
     protected static String manualDirtyTrackingAttributeKey = "__changed__";
 
-    public static void setManualDirtyTrackingAttributeKey(String key) {
+    /**
+     * Allows you to customize name of the attribute used to let the plugin know that the session must be persisted to
+     * Redis, no matter what.
+     *
+     * @param key The name of the flag attribute.
+     */
+    public static void setManualDirtyTrackingAttributeKey(final String key) {
         manualDirtyTrackingAttributeKey = key;
     }
 
     protected HashMap<String, Object> changedAttributes;
     protected boolean dirty = false;
 
-    public RedisSession(Manager manager) {
+    public RedisSession(final Manager manager) {
         super(manager);
-        resetDirtyTracking();
+        this.resetDirtyTracking();
     }
 
+    /**
+     * Determines whether the current session has changed since the last time it was saved based on the following
+     * criteria:
+     * <ul>
+     *     <li>The {@code dirty} flag has been set to {@code true}.</li>
+     *     <li>The Map containing the attributes that have changed is NOT empty.</li>
+     * </ul>
+     *
+     * @return If the session is dirty, returns {@code true}.
+     */
     public boolean isDirty() {
-        return dirty || !changedAttributes.isEmpty();
+        return this.dirty || !this.changedAttributes.isEmpty();
     }
 
+    /**
+     * Returns the Map containing the attributes that have changed since the last time the session was saved.
+     *
+     * @return A Map containing the attributes that have changed.
+     */
     public HashMap<String, Object> getChangedAttributes() {
-        return changedAttributes;
+        return this.changedAttributes;
     }
 
+    /**
+     * Resets the current session to an empty initial state. This method must be called every time (1) the session is
+     * persisted to Redis, and (2) read/deserialized from Redis.
+     */
     public void resetDirtyTracking() {
-        changedAttributes = new HashMap<>();
-        dirty = false;
+        this.changedAttributes = new HashMap<>();
+        this.dirty = false;
     }
 
+    /**
+     * Binds an object to this session, using the specified name. If an object of the same name is already bound to this
+     * session, the object is replaced. When calling this method, the plugin will automatically save the session <b>ONLY
+     * when the following conditions are met</b>:
+     * <ol>
+     *     <li>The {@code TOMCAT_REDIS_SESSION_PERSISTENT_POLICIES} contains the
+     *     {@link RedisSessionManager.SessionPersistPolicy#SAVE_ON_CHANGE} policy in it.</li>
+     *     <li>If it does, then at least one of the following criteria must be met:</li>
+     *     <ol>
+     *         <li>Either the new value or the existing value of the added attribute <b>ARE NOT NULL</b>.</li>
+     *         <li>The class of the new value compared to the existing value is different.</li>
+     *         <li>The new value is actually different from the existing value.</li>
+     *     </ol>
+     * </ol>
+     * <p>
+     * After this method executes, and if the object implements <code>HttpSessionBindingListener</code>, the container
+     * calls <code>valueBound()</code> on the object.
+     *
+     * @param key   Name to which the object is bound, cannot be null
+     * @param value Object to be bound. If it's {@code null}, it'll be removed from the session.
+     *
+     * @throws IllegalArgumentException if an attempt is made to add a non-serializable object in an environment marked
+     *                                  distributable.
+     * @throws IllegalStateException    if this method is called on an invalidated session.
+     */
     @Override
     public void setAttribute(final String key, final Object value) {
         if (manualDirtyTrackingSupportEnabled && manualDirtyTrackingAttributeKey.equals(key)) {
-            dirty = true;
+            this.dirty = true;
             return;
         }
         final Object oldValue = getAttribute(key);
         if (value instanceof Serializable) {
             super.setAttribute(key, value);
         } else {
-            log.warn(String.format("Value of key '%s' is null or not serializable. Removing it from Session '%s'",
-                    key, this.id));
+            if (null != value) {
+                log.warn(String.format("Value of key '%s' is not serializable. Removing it from Session '%s'", key,
+                        this.id));
+            }
             super.removeAttribute(key);
         }
-        if ((value != null || oldValue != null) && (value == null && oldValue != null || oldValue == null && value != null
-                        || !value.getClass().isInstance(oldValue) || !value.equals(oldValue))) {
+        if ((value != null || oldValue != null)
+                && (value == null && oldValue != null
+                || oldValue == null && value != null
+                || !value.getClass().isInstance(oldValue)
+                || !value.equals(oldValue))) {
             if (this.manager instanceof RedisSessionManager && ((RedisSessionManager) this.manager).getSaveOnChange()) {
                 try {
                     ((RedisSessionManager) this.manager).save(this, true);
@@ -78,56 +143,55 @@ public class RedisSession extends StandardSession {
                     log.error("Error saving session '" + this.id + "' on setAttribute (triggered by saveOnChange=true): " + ex.getMessage());
                 }
             } else {
-                changedAttributes.put(key, value);
+                this.changedAttributes.put(key, value);
             }
         }
     }
 
     @Override
-    public void removeAttribute(String name) {
+    public void removeAttribute(final String name) {
         super.removeAttribute(name);
         if (this.manager instanceof RedisSessionManager && ((RedisSessionManager) this.manager).getSaveOnChange()) {
             try {
                 ((RedisSessionManager) this.manager).save(this, true);
-            } catch (IOException ex) {
-                log.error("Error saving session on setAttribute (triggered by saveOnChange=true): " + ex.getMessage());
+            } catch (final IOException ex) {
+                log.error("Error saving session on removeAttribute with name '" + name + "' (triggered by saveOnChange=true): " + ex.getMessage());
             }
         } else {
-            dirty = true;
+            this.dirty = true;
         }
     }
 
     @Override
-    public void setId(String id) {
+    public void setId(final String id) {
         // Specifically do not call super(): it's implementation does unexpected things
         // like calling manager.remove(session.id) and manager.add(session).
-
         this.id = id;
     }
 
     @Override
-    public void setPrincipal(Principal principal) {
-        dirty = true;
+    public void setPrincipal(final Principal principal) {
+        this.dirty = true;
         super.setPrincipal(principal);
     }
 
     @Override
-    public void writeObjectData(java.io.ObjectOutputStream out) throws IOException {
+    public void writeObjectData(final java.io.ObjectOutputStream out) throws IOException {
         try {
             super.writeObjectData(out);
             out.writeLong(this.getCreationTime());
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log.error(e);
             throw e;
         }
     }
 
     @Override
-    public void readObjectData(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    public void readObjectData(final java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         try {
             super.readObjectData(in);
             this.setCreationTime(in.readLong());
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log.error(e);
             throw e;
         }

--- a/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionHandlerValve.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionHandlerValve.java
@@ -33,11 +33,12 @@ public class RedisSessionHandlerValve extends ValveBase {
     }
 
     @Override
-    public void invoke(Request request, Response response) throws IOException, ServletException {
+    public void invoke(final Request request, final Response response) throws IOException, ServletException {
         try {
             getNext().invoke(request, response);
         } finally {
-            manager.afterRequest();
+            this.manager.afterRequest();
         }
     }
+
 }

--- a/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionManager.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionManager.java
@@ -510,7 +510,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
         } catch (final ClassNotFoundException ex) {
             final String errorMsg = "Unable to deserialize data from session ID " + id + ": " + ex.getMessage();
             log.fatal(errorMsg);
-            log.info(ex);
+            log.debug(ex);
             throw new IOException(errorMsg);
         }
         return new DeserializedSessionContainer(session, metadata);
@@ -600,7 +600,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
             }
         } catch (final IOException e) {
             log.error("An error occurred when saving Session " + sessionId + ": " + e.getMessage());
-            log.info(e);
+            log.debug(e);
             throw e;
         }
     }

--- a/src/main/java/com/dotcms/tomcat/redissessions/Serializer.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/Serializer.java
@@ -2,10 +2,57 @@ package com.dotcms.tomcat.redissessions;
 
 import java.io.IOException;
 
+/**
+ * This class allows the Redis Session Manager plugin to serialize the contents of the dotCMS session into a byte array.
+ * This way, it can be persisted to Redis without problems. In case a non-serializable object is added to the session,
+ * an error message will be logged to the {@code dotcms.log} file indicating the name of such an attribute, and the ID
+ * of the session that it was added to.
+ */
 public interface Serializer {
-  void setClassLoader(ClassLoader loader);
 
-  byte[] attributesHashFrom(RedisSession session) throws IOException;
-  byte[] serializeFrom(RedisSession session, SessionSerializationMetadata metadata) throws IOException;
-  void deserializeInto(byte[] data, RedisSession session, SessionSerializationMetadata metadata) throws IOException, ClassNotFoundException;
+    /**
+     * Sets the class loader that will be used to deserialize the session attributes.
+     *
+     * @param loader The provided {@link ClassLoader} instance.
+     */
+    void setClassLoader(final ClassLoader loader);
+
+    /**
+     * Takes the attributes that are present in the specified Redis Session, and transforms them into a byte array.
+     *
+     * @param session The current {@link RedisSession} instance.
+     *
+     * @return A byte array representing the Session attributes.
+     *
+     * @throws IOException An error occurred when transforming the attributes into a byte array.
+     */
+    byte[] attributesHashFrom(final RedisSession session) throws IOException;
+
+    /**
+     * Takes the hash byte array from the Session Serialization Metadata object and writes it into the specified Redis
+     * Session object.
+     *
+     * @param session  The {@link RedisSession} instance that will contain the updated hash byte array.
+     * @param metadata The {@link SessionSerializationMetadata} instance that contains the hash byte array.
+     *
+     * @return The byte array with the Session attributes.
+     *
+     * @throws IOException An error occurred when reading/writing the metadata.
+     */
+    byte[] serializeFrom(final RedisSession session, final SessionSerializationMetadata metadata) throws IOException;
+
+    /**
+     * Takes the serialized byte array and loads them into the specified Redis Session Serialization Metadata instances
+     * so that the attributes can be properly read by the Session Manager.
+     *
+     * @param data     The byte array coming from Redis.
+     * @param session  The {@link RedisSession} that will hold the incoming attributes.
+     * @param metadata The {@link SessionSerializationMetadata} instance that will hold the byte array.
+     *
+     * @throws IOException            An error occurred when processing the byte array.
+     * @throws ClassNotFoundException An error occurred when transforming the byte array into the expected class
+     *                                instance.
+     */
+    void deserializeInto(final byte[] data, final RedisSession session, final SessionSerializationMetadata metadata) throws IOException, ClassNotFoundException;
+
 }

--- a/src/main/java/com/dotcms/tomcat/redissessions/SessionSerializationMetadata.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/SessionSerializationMetadata.java
@@ -1,15 +1,18 @@
 package com.dotcms.tomcat.redissessions;
 
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import org.apache.juli.logging.Log;
-import org.apache.juli.logging.LogFactory;
 
-
+/**
+ * Stores and provides the hash of the Session attributes. An instance of this object is what gets stored in/read from
+ * the Redis server.
+ */
 public class SessionSerializationMetadata implements Serializable {
-
 
     private static final long serialVersionUID = 1L;
 
@@ -22,34 +25,40 @@ public class SessionSerializationMetadata implements Serializable {
     }
 
     public byte[] getSessionAttributesHash() {
-        return sessionAttributesHash;
+        return this.sessionAttributesHash;
     }
 
-    public void setSessionAttributesHash(byte[] sessionAttributesHash) {
+    public void setSessionAttributesHash(final byte[] sessionAttributesHash) {
         this.sessionAttributesHash = sessionAttributesHash;
     }
 
-    public void copyFieldsFrom(SessionSerializationMetadata metadata) {
+    /**
+     * Takes the available properties exposed by the Session Serialization Metadata object and copies them into this
+     * instance.
+     *
+     * @param metadata The {@link SessionSerializationMetadata} instance whose values need to be read.
+     */
+    public void copyFieldsFrom(final SessionSerializationMetadata metadata) {
         this.setSessionAttributesHash(metadata.getSessionAttributesHash());
     }
 
-    private void writeObject(ObjectOutputStream out) throws Exception {
+    private void writeObject(final ObjectOutputStream out) throws Exception {
         try {
-            out.writeInt(sessionAttributesHash.length);
+            out.writeInt(this.sessionAttributesHash.length);
             out.write(this.sessionAttributesHash);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log.error(e);
             throw e;
         }
     }
 
-    private void readObject(ObjectInputStream in) throws Exception {
+    private void readObject(final ObjectInputStream in) throws Exception {
         try {
             int hashLength = in.readInt();
             byte[] sessionAttributesHash = new byte[hashLength];
             in.read(sessionAttributesHash, 0, hashLength);
             this.sessionAttributesHash = sessionAttributesHash;
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log.error(e);
             throw e;
         }

--- a/src/main/java/com/dotcms/tomcat/util/ConfigUtil.java
+++ b/src/main/java/com/dotcms/tomcat/util/ConfigUtil.java
@@ -1,7 +1,10 @@
 package com.dotcms.tomcat.util;
 
 /**
- * Utility class that provides useful methods to access configuration properties for this plugin.
+ * Utility class that provides useful methods to access configuration properties for this plugin. If a property needs to
+ * be added, removed or have its default value updated, make sure that the
+ * {@code docker/dotcms/ROOT/srv/00-config-defaults.sh} file in the dotCMS Core repository is updated accordingly. This
+ * way, such changes will be available as environment variables configurable in a Docker instance.
  *
  * @author Jose Castro
  * @since May 3rd, 2023
@@ -20,9 +23,9 @@ public class ConfigUtil {
     public static final String REDIS_MAX_IDLE_CONNECTIONS_PROPERTY = "${TOMCAT_REDIS_MAX_IDLE_CONNECTIONS";
     public static final String REDIS_MIN_IDLE_CONNECTIONS_PROPERTY = "${TOMCAT_REDIS_MIN_IDLE_CONNECTIONS";
     public static final String REDIS_PERSISTENT_POLICIES_PROPERTY = "${TOMCAT_REDIS_SESSION_PERSISTENT_POLICIES}";
-
-    public static final String DOTCMS_CLUSTER_ID_PROPERTY = "${DOT_DOTCMS_CLUSTER_ID}";
     public static final String REDIS_ENABLED_FOR_ANON_TRAFFIC = "${TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC}";
+    public static final String REDIS_UNDEFINED_SESSION_TYPE_TIMEOUT = "${TOMCAT_REDIS_UNDEFINED_SESSION_TYPE_TIMEOUT}";
+    public static final String DOTCMS_CLUSTER_ID_PROPERTY = "${DOT_DOTCMS_CLUSTER_ID}";
 
     /**
      * Returns the String value of the specified configuration property. Such a key can represent a Java Property or an
@@ -33,7 +36,7 @@ public class ConfigUtil {
      * @return The String value of the specified configuration property.
      */
     public static String getConfigProperty(String key) {
-        if (null == key) {
+        if (null == key || key.isEmpty()) {
             return null;
         }
         int fromIndex = 0;
@@ -67,7 +70,8 @@ public class ConfigUtil {
      *
      * @return The String value of the specified configuration property.
      */
-    public static <T> T getConfigProperty(String key, final T defaultValue) {
+    @SuppressWarnings("unchecked")
+    public static <T> T getConfigProperty(final String key, final T defaultValue) {
         final Object propertyValue = getConfigProperty(key);
         if (null == propertyValue || key.equals(propertyValue)) {
             return defaultValue;


### PR DESCRIPTION
### Proposed Changes
- Added missing Javadoc.
- Fixed some code issues.
- Fixed the behavior in which clustered instances were not able to access the same session object. This is caused by the plugin **ONLY** persisting authenticated back-end or front-end sessions, which was the intended behavior initially. However, we need a way for the other nodes in the cluster to be able to access the same session. The proposed solution is to persist all sessions to Redis **BUT only for a few seconds** -- and also in Tomcat's memory as fallback -- so that all nodes will be able to see it.
- The TTL in seconds for those "undefined session types" is configurable via the `TOMCAT_REDIS_UNDEFINED_SESSION_TYPE_TIMEOUT` property.