### PR TITLE
fix(Redis) dotCMS/core#29355 : Sessions expiring unexpectedly when using Redis

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -124,6 +124,13 @@ SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
 12-Jun-2023 10:16:30.568 INFO [main] com.dotcms.tomcat.redissessions.RedisSessionManager.initializeRedisConnection - 
 ```
 
+For security reasons, the values of following two properties:
+
+* `TOMCAT_REDIS_SESSION_USERNAME`
+* `TOMCAT_REDIS_SESSION_PASSWORD`
+
+Will NOT be displayed in the log. Instead, the String `- Set -` will be displayed if a value has been set for them, and `- Not Set -` if it hasn't.
+
 The success message at the bottom is the key indicator that the plugin has successfully connected to Redis and is ready to receive data. By default, only sessions created by dotCMS for either the back-end or the front-end will be persisted to Redis. If you want to persist sessions created by anonymous traffic, you can set the `TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC` property to `true`.
 
 Allowing multiple clusters to share the same session Redis store can be a very smart strategy. In order to accomplish this, you can specify the ID of the cluster via the `DOT_DOTCMS_CLUSTER_ID` property which is used to prefix all keys persisted to Redis. 
@@ -157,7 +164,8 @@ Local Environment Setup
 In your local environment, you need to go to the Tomcat `context.xml` file, scroll down to the bottom, and add the following code:
 ```xml
     <Valve className="com.dotcms.tomcat.redissessions.RedisSessionHandlerValve" />
-    <Manager className="com.dotcms.tomcat.redissessions.RedisSessionManager" />
+    <Manager className="com.dotcms.tomcat.redissessions.RedisSessionManager"
+         password="YOUR_P4SS_HERE"/>
 ```
 For the plugin to be activated when dotCMS starts up. This configuration is what actually enables this plugin, so once you comment it back, dotCMS will go back to letting Tomcat handle its Sessions, as usual.
 
@@ -181,15 +189,15 @@ services:
       - redis_net
 ```
 
-If you need to set up a Redis Server that requires both username and password, please refer to the sample `docker-compose` file here: `docker-compose-examples/redis-with-usr-pwd/redis/docker-compose.yml`.
+**IMPORTANT:** If you need to set up a Redis Server that requires both username and password, please refer to the sample `docker-compose` file here: `docker-compose-examples/redis-with-usr-pwd/redis/docker-compose.yml`.
 
-Please refer to the `Configuration Parameters` section in case you need to enable/disable additional configuration properties for Redis via Environment Variables or Java Properties.
+Please refer to the `Configuration Parameters` section in case you need to enable/disable additional configuration properties for Redis via Environment Variables or Java Properties. For instance, when using the `docker-compose` file above, you'll need to specify both the `username` and `password` attributes.
 
 
 Connection Pool Configuration
 -----------------------------
 
-All the configuration options from both `org.apache.commons.pool2.impl.GenericObjectPoolConfig` and `org.apache.commons.pool2.impl.BaseObjectPoolConfig` are also configurable for the Redis connection pool used by the session manager. To configure any of these attributes (e.g., `maxIdle` and `testOnBorrow`) just use the config attribute name prefixed with `connectionPool` (e.g., `connectionPoolMaxIdle` and `connectionPoolTestOnBorrow`) and set the desired value in the `<Manager>` declaration in your Tomcat context.xml.
+All the configuration options from both `org.apache.commons.pool2.impl.GenericObjectPoolConfig` and `org.apache.commons.pool2.impl.BaseObjectPoolConfig` are also configurable for the Redis connection pool used by the session manager. To configure any of these attributes (e.g., `maxIdle` and `testOnBorrow`) just use the config attribute name prefixed with `connectionPool` (e.g., `connectionPoolMaxIdle` and `connectionPoolTestOnBorrow`) and set the desired value in the `<Manager>` declaration in your Tomcat's `context.xml` file.
 
 
 Plugin's Logging
@@ -197,7 +205,7 @@ Plugin's Logging
 
 By default, and for security reasons, minimal initialization information is logged when dotCMS starts up. This is basically meant to let you know that the plugin is actually present, and is enabled. If more detailed information is required, you just need to follow these steps:
 
-* Go to `{TOMCAT_HOME}/conf/logging.properties` file.
+* Go to the `{TOMCAT_HOME}/conf/logging.properties` file.
 * Scroll down to the bottom, and add an entry for every class in this plugin for which you want to increase the logging level. For instance, if you need the `RedisSessionManager` class to log more information, add this:
 ```
 com.dotcms.tomcat.redissessions.RedisSessionManager.level = FINE

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 
 group = 'com.dotcms'
-version = '1.2'
+version = '1.3'
 
 repositories {
   mavenCentral()

--- a/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionManager.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionManager.java
@@ -64,31 +64,36 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
 
     protected static final byte[] NULL_SESSION = "null".getBytes();
     private final Log log = LogFactory.getLog(RedisSessionManager.class);
+
     protected String host = "localhost";
     protected int port = Protocol.DEFAULT_PORT;
-    protected int database = Protocol.DEFAULT_DATABASE;
     protected String username = null;
     protected String password = null;
+    protected boolean ssl = false;
     protected int timeout = Protocol.DEFAULT_TIMEOUT;
-    protected String sentinelMaster = null;
-    Set<String> sentinelSet = null;
     protected int maxTotal = 128;
     protected int maxIdle = 100;
     protected int minIdle = 32;
     protected String prefix = "";
+    protected int database = Protocol.DEFAULT_DATABASE;
+    protected String sentinelMaster = null;
+    Set<String> sentinelSet = null;
+
     protected boolean isAnonTrafficEnabled = false;
     protected int undefinedSessionTypeTimeout = 15;
+
     protected UnifiedJedis jedisPool;
     protected ConnectionPoolConfig connectionPoolConfig = this.buildPoolConfig();
-    protected boolean ssl = false;
     protected RedisSessionHandlerValve handlerValve;
+
     protected ThreadLocal<RedisSession> currentSession = new ThreadLocal<>();
     protected ThreadLocal<SessionSerializationMetadata> currentSessionSerializationMetadata =
                     new ThreadLocal<>();
     protected ThreadLocal<String> currentSessionId = new ThreadLocal<>();
     protected ThreadLocal<Boolean> currentSessionIsPersisted = new ThreadLocal<>();
+
     protected Serializer serializer;
-    protected String serializationStrategyClass = "com.dotcms.tomcat.redissessions.JavaSerializer";
+    protected String serializationStrategyClass = JavaSerializer.class.getName();
     protected EnumSet<SessionPersistPolicy> sessionPersistPoliciesSet = EnumSet.of(SessionPersistPolicy.DEFAULT);
 
     /**
@@ -315,11 +320,12 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     protected synchronized void startInternal() throws LifecycleException {
         super.startInternal();
         setState(LifecycleState.STARTING);
-        log.info("========================================================================");
-        log.info(" ");
-        log.info("                   Redis-based Tomcat Session plugin");
-        log.info(" ");
-        log.info("========================================================================");
+        log.info("\n" +
+                "========================================================================\n" +
+                "\n" +
+                "                   Redis-based Tomcat Session plugin\n" +
+                "\n" +
+                "========================================================================");
         boolean attachedToValve = false;
         for (final Valve valve : getContext().getPipeline().getValves()) {
             if (valve instanceof RedisSessionHandlerValve) {
@@ -339,7 +345,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
             this.initializeSerializer();
         } catch (final ClassNotFoundException | NoSuchMethodException | InvocationTargetException |
                        InstantiationException | IllegalAccessException e) {
-            log.fatal(String.format("FATAL - Unable to load Java serializer: %s", e.getMessage()));
+            log.fatal(String.format("FATAL - Unable to load Java Serializer: %s", e.getMessage()));
             log.debug(e);
             throw new LifecycleException(e);
         }
@@ -603,11 +609,11 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
             if (null == ((RedisSession) session).getAttribute(RedisSession.DOT_CLUSTER_SESSION) && !this.isAnonTrafficEnabled) {
                 log.debug(String.format("Session [ %s ] doesn't seem to belong to a back-end request. Setting expiration time to " +
                         "%d seconds", sessionId, this.undefinedSessionTypeTimeout));
-                this.setSessionExpiration(sessionId, this.undefinedSessionTypeTimeout);
+                this.setSessionExpiration(session, this.undefinedSessionTypeTimeout);
                 super.add(session);
             } else {
                 log.debug(String.format("Setting expire timeout on session [ %s ] to %d seconds", sessionId, this.getTomcatSessionTimeoutInSeconds()));
-                this.setSessionExpiration(sessionId, this.getTomcatSessionTimeoutInSeconds());
+                this.setSessionExpiration(session, this.getTomcatSessionTimeoutInSeconds());
             }
         } catch (final IOException e) {
             log.error(String.format("An error occurred when saving Session [ %s ]: %s", sessionId, e.getMessage()));
@@ -617,16 +623,19 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     }
 
     /**
-     * Sets the expiration time for the newly created Session, as this process will be completely handled by Redis.
-     * <p>If the value for the {@code DOT_DOTCMS_CLUSTER_ID} is specified, it'll be used to prefix they key. Doing this
-     * will allow multiple clusters to share the same Session Redis Store.</p>
+     * Sets the expiration time for the newly created Session, as this process will be completely
+     * handled by Redis.
+     * <p>If the value for the {@code DOT_DOTCMS_CLUSTER_ID} is specified, it'll be used to prefix
+     * they key. Doing this will allow multiple clusters to share the same Session Redis Store.</p>
      *
-     * @param sessionId The ID of the Session whose TTL is being set.
-     * @param seconds   The number of seconds after which the Session will expire.
+     * @param session The {@link Session} object whose TTL is being set.
+     * @param seconds The number of seconds after which the Session will expire.
      */
-    protected void setSessionExpiration(final String sessionId, final long seconds) {
-        final String prefixedKey = this.prefix + sessionId;
+    protected void setSessionExpiration(final Session session, final long seconds) {
+        final String prefixedKey = this.prefix + session.getId();
         this.jedisPool.expire(prefixedKey.getBytes(), seconds);
+        session.setMaxInactiveInterval((int) seconds);
+        super.add(session);
     }
 
     @Override
@@ -713,7 +722,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
      * value in order to make the plugin work.
      */
     private void initializeConfigParams() {
-        log.info("-> Loading configuration parameters:");
+        log.info("-> Loading configuration parameters...");
         this.host = ConfigUtil.getConfigProperty(ConfigUtil.REDIS_HOST_PROPERTY, this.host);
         this.port = ConfigUtil.getConfigProperty(ConfigUtil.REDIS_PORT_PROPERTY, this.port);
         this.username = ConfigUtil.getConfigProperty(ConfigUtil.REDIS_USERNAME_PROPERTY, this.username);
@@ -738,25 +747,23 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
         this.prefix = ConfigUtil.getConfigProperty(ConfigUtil.DOTCMS_CLUSTER_ID_PROPERTY, this.prefix);
         this.isAnonTrafficEnabled = ConfigUtil.getConfigProperty(ConfigUtil.REDIS_ENABLED_FOR_ANON_TRAFFIC, this.isAnonTrafficEnabled);
         this.undefinedSessionTypeTimeout = ConfigUtil.getConfigProperty(ConfigUtil.REDIS_UNDEFINED_SESSION_TYPE_TIMEOUT, this.undefinedSessionTypeTimeout);
-        log.info("[✓] TOMCAT_REDIS_SESSION_HOST: " + this.getHost());
-        log.info("[✓] TOMCAT_REDIS_SESSION_PORT: " + this.getPort());
-        log.info("[✓] TOMCAT_REDIS_SESSION_USERNAME: "
-                + (null == this.username || this.username.isEmpty() ? "- Not Set -" : "- Set -"));
-        log.info("[✓] TOMCAT_REDIS_SESSION_PASSWORD: "
-                + (null == this.password || this.password.isEmpty() ? "- Not Set -" : "- Set -"));
-        log.info("[✓] TOMCAT_REDIS_SESSION_SSL_ENABLED: " + this.getSsl());
-        log.info("[✓] TOMCAT_REDIS_SESSION_SENTINEL_MASTER: " + this.getSentinelMaster());
-        log.info("[✓] TOMCAT_REDIS_SESSION_SENTINELS: " + this.getSentinels());
-        log.info("[✓] TOMCAT_REDIS_SESSION_DATABASE: " + this.getDatabase());
-        log.info("[✓] TOMCAT_REDIS_SESSION_TIMEOUT: " + this.getTimeout());
-        log.info("[✓] TOMCAT_REDIS_SESSION_PERSISTENT_POLICIES: " + this.getSessionPersistPolicies());
-        log.info("[✓] TOMCAT_REDIS_MAX_CONNECTIONS: " + this.maxTotal);
-        log.info("[✓] TOMCAT_REDIS_MAX_IDLE_CONNECTIONS: " + this.maxIdle);
-        log.info("[✓] TOMCAT_REDIS_MAX_IDLE_CONNECTIONS: " + this.minIdle);
-        log.info("[✓] TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC: " + this.isAnonTrafficEnabled);
-        log.info("[✓] TOMCAT_REDIS_UNDEFINED_SESSION_TYPE_TIMEOUT: " + this.undefinedSessionTypeTimeout);
-        log.info("[✓] DOT_DOTCMS_CLUSTER_ID (Redis Key Prefix): "
-                + (null == this.prefix || this.prefix.isEmpty() ? "- Not Set -" : this.prefix));
+        log.info("\n[✓] TOMCAT_REDIS_SESSION_HOST: " + this.getHost() +
+                "\n[✓] TOMCAT_REDIS_SESSION_PORT: " + this.getPort() +
+                "\n[✓] TOMCAT_REDIS_SESSION_USERNAME: " + (null == this.username || this.username.isEmpty() ? "- Not Set -" : "- Set -") +
+                "\n[✓] TOMCAT_REDIS_SESSION_PASSWORD: " + (null == this.password || this.password.isEmpty() ? "- Not Set -" : "- Set -") +
+                "\n[✓] TOMCAT_REDIS_SESSION_SSL_ENABLED: " + this.getSsl() +
+                "\n[✓] TOMCAT_REDIS_SESSION_SENTINEL_MASTER: " + this.getSentinelMaster() +
+                "\n[✓] TOMCAT_REDIS_SESSION_SENTINELS: " + this.getSentinels() +
+                "\n[✓] TOMCAT_REDIS_SESSION_DATABASE: " + this.getDatabase() +
+                "\n[✓] TOMCAT_REDIS_SESSION_TIMEOUT: " + this.getTimeout() +
+                "\n[✓] TOMCAT_REDIS_SESSION_PERSISTENT_POLICIES: " + this.getSessionPersistPolicies() +
+                "\n[✓] TOMCAT_REDIS_MAX_CONNECTIONS: " + this.maxTotal +
+                "\n[✓] TOMCAT_REDIS_MAX_IDLE_CONNECTIONS: " + this.maxIdle +
+                "\n[✓] TOMCAT_REDIS_MAX_IDLE_CONNECTIONS: " + this.minIdle +
+                "\n[✓] TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC: " + this.isAnonTrafficEnabled +
+                "\n[✓] TOMCAT_REDIS_UNDEFINED_SESSION_TYPE_TIMEOUT: " + this.undefinedSessionTypeTimeout +
+                "\n[✓] DOT_DOTCMS_CLUSTER_ID (Redis Key Prefix): " +
+                    (null == this.prefix || this.prefix.isEmpty() ? "- Not Set -" : this.prefix));
     }
 
     /**
@@ -772,9 +779,9 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
                     ? new JedisPooled(this.connectionPoolConfig, getHost(), getPort(), getTimeout(), getPassword(), getSsl())
                     : new JedisPooled(this.connectionPoolConfig, getHost(), getPort(), getTimeout(), getUsername(), getPassword(), getSsl());
             jedisPool.ping();
-            log.info("");
-            log.info("   Successful! Redis-based Tomcat Sessions will expire after " + this.getTomcatSessionTimeoutInSeconds() + " seconds.");
-            log.info("");
+            log.info("\n\n" +
+                    "    Successful! Redis-based Tomcat Sessions will expire after " + this.getTomcatSessionTimeoutInSeconds() + " seconds.\n" +
+                    " ");
         } catch (final Exception e) {
             throw new LifecycleException("FATAL - Failed to connect to Redis. Please check that the server is available, and " +
                     "parameters such as the host, port, and username/password are correct.", e);
@@ -795,7 +802,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
      */
     private void initializeSerializer() throws ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, InstantiationException, IllegalAccessException {
-        log.debug(String.format("-> Attempting to use serializer: %s", this.serializationStrategyClass));
+        log.info(String.format("-> Initializing Java Serializer: '%s'", this.serializationStrategyClass));
         final Class<?> serializerClass = Class.forName(this.serializationStrategyClass);
         this.serializer = (Serializer) serializerClass.getDeclaredConstructor().newInstance();
         final Loader loader = null != getContext() ? getContext().getLoader() : null;


### PR DESCRIPTION
### Proposed Changes
* Updating the TTL in the fallback Tomcat's session as well so that the logout never happens as long as Users are still active.