### PR TITLE
fix(Redis): don't expire redis sessions from tomcat expiration thread

### DIFF
--- a/SESSION-EXPIRATION-GUIDE.md
+++ b/SESSION-EXPIRATION-GUIDE.md
@@ -1,0 +1,637 @@
+# Session Expiration in Redis Session Manager: A Complete Guide
+
+## Table of Contents
+1. [Introduction](#introduction)
+2. [Session Types](#session-types)
+3. [The Dual Storage Architecture](#the-dual-storage-architecture)
+4. [How Session Expiration Works](#how-session-expiration-works)
+5. [The Problem We Faced](#the-problem-we-faced)
+6. [Why We Override processExpires()](#why-we-override-processexpires)
+7. [Why We Override isValid()](#why-we-override-isvalid)
+8. [The Complete Solution](#the-complete-solution)
+9. [Examples and Scenarios](#examples-and-scenarios)
+
+---
+
+## Introduction
+
+This document explains how session expiration works in the Redis Session Manager, the problems we encountered with Tomcat's standard expiration logic, and the solutions we implemented.
+
+**The Core Problem**: Tomcat's standard session expiration mechanism was incorrectly expiring sessions that were still active in Redis, causing users to lose their sessions unexpectedly in clustered environments.
+
+**The Solution**: Override key methods (`processExpires()` and `isValid()`) to implement session-type-aware expiration logic that uses Redis as the source of truth for session activity.
+
+---
+
+## Session Types
+
+The Redis Session Manager handles two types of sessions with different expiration strategies:
+
+### 1. Undefined Sessions (Anonymous/Unauthenticated)
+
+**Characteristics**:
+- No `DOT_CLUSTER_SESSION_ATTR` attribute set
+- Typically new visitors who haven't logged in
+- Short-lived in Redis (15 seconds by default)
+- Managed by Tomcat's expiration logic
+
+**Redis Storage**:
+- TTL: 15 seconds (configurable via `TOMCAT_REDIS_UNDEFINED_SESSION_TYPE_TIMEOUT`)
+- Purpose: Cluster coordination during authentication
+- After 15s, Redis auto-deletes the entry
+
+**Expiration**:
+- **Managed by**: Tomcat's `processExpires()` based on idle time
+- **Max Inactive Interval**: Standard Tomcat timeout (e.g., 1800s)
+- **Logic**: If idle time exceeds max inactive interval, Tomcat expires the session
+
+**Why This Design**:
+- Most anonymous sessions never authenticate
+- No need to burden Redis with long-term storage
+- Tomcat is efficient at managing local sessions
+- 15s Redis window prevents cluster race conditions during login
+
+### 2. Authenticated Sessions (Redis-Managed)
+
+**Characteristics**:
+- Has `DOT_CLUSTER_SESSION_ATTR` attribute set
+- User has logged in
+- Long-lived in Redis (1800 seconds by default)
+- Managed by Redis TTL expiration
+
+**Redis Storage**:
+- TTL: 1800 seconds (configurable via `TOMCAT_REDIS_USER_SESSION_TIMEOUT`)
+- Purpose: Cluster-consistent session management
+- TTL refreshed on every access
+
+**Expiration**:
+- **Managed by**: Redis TTL auto-expiration
+- **Max Inactive Interval**: Same as Redis TTL (1800s)
+- **Logic**: When Redis TTL reaches 0, Redis auto-deletes the session
+
+**Why This Design**:
+- Authenticated users need cluster-wide session availability
+- Redis TTL ensures consistent expiration across all nodes
+- No node can have stale session data
+- User experience is consistent regardless of which node they hit
+
+---
+
+## The Dual Storage Architecture
+
+### Storage Strategy
+
+**All sessions are stored in BOTH Redis and Tomcat**:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    NEW SESSION                          │
+│                         ↓                               │
+│         ┌───────────────────────────────┐              │
+│         │    Stored in BOTH locations:   │              │
+│         │                                 │              │
+│         │  1. Redis (with TTL)           │              │
+│         │  2. Tomcat (in-memory)         │              │
+│         └───────────────────────────────┘              │
+│                         ↓                               │
+│            Expiration Strategy Depends On:             │
+│                                                         │
+│    ┌─────────────────┬─────────────────────┐          │
+│    │  Undefined      │  Authenticated      │          │
+│    │  (no attribute) │  (has attribute)    │          │
+│    ├─────────────────┼─────────────────────┤          │
+│    │ Redis: 15s TTL  │ Redis: 1800s TTL    │          │
+│    │ Expires in:     │ Expires in:         │          │
+│    │ Tomcat          │ Redis               │          │
+│    └─────────────────┴─────────────────────┘          │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Why Dual Storage?
+
+1. **Cluster Coordination**: New sessions need to be visible across all nodes immediately
+2. **Flexible Expiration**: Different strategies for different session types
+
+---
+
+## How Session Expiration Works
+
+### Standard Tomcat Expiration (Base Class Behavior)
+
+Tomcat's `StandardManager` has a background thread that runs `processExpires()` periodically (typically every 6 seconds):
+
+```java
+// StandardManager.processExpires() logic (simplified)
+public void processExpires() {
+    Session[] sessions = findSessions();
+
+    for (Session session : sessions) {
+        if (session.isValid()) {
+            // Session is still valid after idle time check
+            // Keep it
+        } else {
+            // Session expired (isValid() returned false)
+            // It was already expired by isValid() check
+        }
+    }
+}
+```
+
+The key is in `isValid()`:
+
+```java
+// StandardSession.isValid() logic (simplified)
+public boolean isValid() {
+    if (!this.valid) {
+        return false;  // Already marked invalid
+    }
+
+    // Check idle time
+    if (maxInactiveInterval > 0) {
+        long timeIdle = (System.currentTimeMillis() - this.lastAccessedTime) / 1000L;
+        if (timeIdle >= maxInactiveInterval) {
+            expire();  // Expire the session
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+**Key Point**: `isValid()` checks idle time and **automatically expires** the session if it's been idle too long.
+
+---
+
+## The Problem We Faced
+
+### Problem 1: Stale lastAccessedTime After Save/Load Cycles
+
+**Scenario**:
+```
+T=0:   Session created, lastAccessedTime = 0
+T=5:   User accesses page on Node A
+       Session saved to Redis
+       lastAccessedTime = 0 (stored in serialized form)
+
+T=10:  User accesses page on Node B
+       Session loaded from Redis
+       lastAccessedTime = 0 (restored from serialized data - STALE!)
+       Session processed and saved to Redis
+       lastAccessedTime still = 0
+
+T=30:  processExpires() runs on Node B
+       Calculates: timeIdle = 30 - 0 = 30 seconds
+
+       If maxInactiveInterval = 20 seconds:
+       30 >= 20 → Session expired prematurely! ✗
+
+       But user was just active at T=10!
+```
+
+**Root Cause**: The `lastAccessedTime` field in the serialized session data doesn't reflect all the intermediate accesses that happened during save/load cycles.
+
+### Problem 2: Redis-Managed Sessions Expired by Tomcat
+
+**Scenario**:
+```
+Authenticated session in cluster:
+  Node A: User actively using the application
+          lastAccessedTime = recent
+
+  Node B: No direct access, but has session in Tomcat
+          lastAccessedTime = 30 minutes ago (stale)
+
+  Node B's processExpires() runs:
+    Checks: timeIdle = 30 minutes
+    Compares: 30 minutes >= maxInactiveInterval (30 minutes)
+    Result: Expires the session! ✗
+
+  Meanwhile, Redis still has the session (user is active on Node A)
+
+  Next request to Node B:
+    findSession() returns null (expired)
+    User loses session despite being active! ✗
+```
+
+**Root Cause**: Each cluster node tracks its own `lastAccessedTime`. Node-specific idle time checks cause inconsistent expiration across the cluster.
+
+### Problem 3: Cluster Race Condition
+
+**Scenario**:
+```
+T=0:   User visits application
+       Node A creates session
+       Saves to Redis with 15s TTL
+
+T=0.5: Load balancer routes next request to Node B
+       Node B: No session found locally
+       Node B: Queries Redis → Session found! ✓
+       Session continues seamlessly
+
+WITHOUT the 15s Redis window:
+T=0.5: Node B: Queries Redis → Not found (Node A hasn't saved yet)
+       Node B: Creates NEW session → User loses original session ✗
+```
+
+**Root Cause**: Without temporary Redis storage, new sessions aren't immediately visible to other cluster nodes.
+
+---
+
+## Why We Override processExpires()
+
+### The Standard processExpires() Problem
+
+Tomcat's `StandardManager.processExpires()` calls `isValid()` on every session, which:
+1. Checks the `valid` flag
+2. **Checks idle time** using `lastAccessedTime`
+3. Expires the session if idle too long
+
+**This doesn't work for us because**:
+- `lastAccessedTime` becomes stale after save/load cycles
+- Redis-managed sessions shouldn't be expired by Tomcat's local idle time checks
+- We need different logic for different session types
+
+### Our Override Solution
+
+```java
+@Override
+public void processExpires() {
+    Session[] sessions = findSessions();
+    long timeNow = System.currentTimeMillis();
+
+    for (Session session : sessions) {
+        RedisSession redisSession = (RedisSession) session;
+
+        // CRITICAL: Check validity first to avoid IllegalStateException
+        if (!redisSession.isValid()) {
+            continue;  // Skip invalid sessions
+        }
+
+        if (redisSession.getAttribute(DOT_CLUSTER_SESSION_ATTR) == null
+                && !this.isAnonTrafficEnabled) {
+            // ============================================
+            // Case 1: Undefined Session (Tomcat-managed)
+            // ============================================
+            if (!redisSession.isNew()) {
+                // Get ACCURATE lastAccessedTime from Redis TTL
+                long lastAccessedTime = redisSession.getLastAccessedTime();
+                int maxInactiveInterval = redisSession.getMaxInactiveInterval();
+                long timeIdle = (timeNow - lastAccessedTime) / 1000L;
+
+                // Expire if truly idle
+                if (maxInactiveInterval > 0 && timeIdle >= maxInactiveInterval) {
+                    redisSession.expire();
+                }
+            }
+        } else {
+            // ================================================
+            // Case 2: Authenticated Session (Redis-managed)
+            // ================================================
+            // Check if session still exists in Redis
+            if (!existsInRedis(redisSession.getId())) {
+                // Redis TTL expired → Expire in Tomcat too
+                redisSession.expire();
+            }
+            // If exists in Redis → Keep alive (Redis manages expiration)
+        }
+    }
+}
+```
+
+### Key Improvements
+
+1. **Session-Type-Aware Logic**:
+   - Undefined sessions: Use accurate idle time from Redis TTL
+   - Authenticated sessions: Check Redis existence, don't use idle time
+
+2. **Accurate lastAccessedTime**:
+   - Calculated from Redis TTL (source of truth)
+   - Formula: `lastAccessedTime = currentTime - (originalTTL - remainingTTL)`
+   - Prevents stale timestamp issues
+
+3. **Memory Leak Prevention**:
+   - Detects sessions expired in Redis but still in Tomcat
+   - Cleans them up to prevent memory growth
+
+---
+
+## Why We Override isValid()
+
+### The Standard isValid() Problem
+
+Tomcat's `StandardSession.isValid()`:
+```java
+public boolean isValid() {
+    if (!this.valid) {
+        return false;
+    }
+
+    // PROBLEM: Always checks idle time
+    if (maxInactiveInterval > 0) {
+        long timeIdle = (System.currentTimeMillis() - this.lastAccessedTime) / 1000L;
+        if (timeIdle >= maxInactiveInterval) {
+            expire();  // Expires Redis-managed sessions prematurely!
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+**This doesn't work for Redis-managed sessions because**:
+- Each cluster node has different `lastAccessedTime`
+- Node-specific idle time checks cause inconsistent expiration
+- Redis-managed sessions should ONLY be expired by Redis TTL, not local checks
+
+### Our Override Solution
+
+```java
+@Override
+public boolean isValid() {
+    // CRITICAL: Check valid flag FIRST (prevent IllegalStateException)
+    if (!getValidFlag()) {
+        return false;
+    }
+
+    if (this.manager instanceof RedisSessionManager) {
+        RedisSessionManager redisManager = (RedisSessionManager) this.manager;
+
+        // Check if this is a Redis-managed session
+        boolean isRedisManagedSession =
+                this.getAttribute(DOT_CLUSTER_SESSION_ATTR) != null
+                || redisManager.isAnonTrafficEnabled();
+
+        if (isRedisManagedSession) {
+            // ================================================
+            // Redis-Managed Session:
+            // Only check valid flag, skip idle time checks
+            // ================================================
+            return true;  // Already checked valid flag above
+        }
+    }
+
+    // ================================================
+    // Tomcat-Managed Session (Undefined):
+    // Delegate to base class (includes idle time check)
+    // ================================================
+    return super.isValid();
+}
+```
+
+### Key Improvements
+
+1. **Session-Type-Aware Validation**:
+   - Redis-managed: Only check valid flag (no idle time check)
+   - Tomcat-managed: Full validation including idle time
+
+2. **Prevents Premature Expiration**:
+   - Redis-managed sessions aren't expired by Tomcat's local logic
+   - Expiration managed consistently by Redis TTL across all nodes
+
+3. **Cluster Consistency**:
+   - All nodes return same result for Redis-managed sessions
+   - No node-specific expiration decisions
+
+---
+
+## The Complete Solution
+
+### How lastAccessedTime is Calculated
+
+Instead of using the stale stored value, we calculate from Redis TTL:
+
+```java
+@Override
+public long getLastAccessedTime() {
+    // Check validity first
+    if (!getValidFlag()) {
+        throw new IllegalStateException("Session already invalidated");
+    }
+
+    if (this.manager instanceof RedisSessionManager) {
+        RedisSessionManager redisManager = (RedisSessionManager) this.manager;
+
+        try {
+            // Query Redis for remaining TTL
+            long remainingTTL = redisManager.getRemainingTTL(this.getId());
+
+            if (remainingTTL >= 0) {
+                // Determine the original TTL that was set in Redis
+                // IMPORTANT: For undefined sessions, Redis TTL != maxInactiveInterval!
+                long originalTTL;
+                if (this.getAttribute(DOT_CLUSTER_SESSION_ATTR) != null
+                        || redisManager.isAnonTrafficEnabled()) {
+                    // Authenticated: Redis TTL = maxInactiveInterval (1800s)
+                    originalTTL = this.getMaxInactiveInterval();
+                } else {
+                    // Undefined: Redis TTL = undefinedSessionTypeTimeout (15s)
+                    originalTTL = redisManager.getUndefinedSessionTypeTimeout();
+                }
+
+                // Calculate time since last access
+                long timeSinceLastAccess = (originalTTL - remainingTTL) * 1000L;
+                long currentTime = System.currentTimeMillis();
+                long calculatedLastAccessedTime = currentTime - timeSinceLastAccess;
+
+                // Get stored value
+                long storedLastAccessedTime = super.getLastAccessedTime();
+
+                // Return most recent (handles edge cases)
+                return Math.max(calculatedLastAccessedTime, storedLastAccessedTime);
+            }
+        } catch (Exception e) {
+            // Fall back to stored value if Redis unavailable
+        }
+    }
+
+    return super.getLastAccessedTime();
+}
+```
+
+**Why This Works**:
+- Redis TTL is refreshed on every access (across all nodes)
+- TTL difference tells us exactly how long since last access
+- Always accurate, regardless of save/load cycles
+
+**CRITICAL: originalTTL vs maxInactiveInterval**:
+- For **undefined sessions**: Redis TTL (15s) ≠ maxInactiveInterval (1800s)
+  - Must use `undefinedSessionTypeTimeout` (15s) as originalTTL
+  - Using maxInactiveInterval would give completely wrong results!
+- For **authenticated sessions**: Redis TTL (1800s) = maxInactiveInterval (1800s)
+  - Can use either value (they're synchronized)
+- The `getLastAccessedTime()` method checks session type to determine correct originalTTL
+
+---
+
+## Examples and Scenarios
+
+### Example 1: Undefined Session (Tomcat-Managed)
+
+```
+Timeline:
+---------
+T=0:   User visits site
+       Session created
+       Saved to Redis: TTL = 15s
+       Saved to Tomcat: maxInactiveInterval = 1800s
+
+T=10:  Session accessed on Node A
+       Saved to Redis: TTL = 15s (refreshed)
+       storedLastAccessedTime = 0 (stale!)
+
+T=20:  Session loaded on Node B
+       storedLastAccessedTime = 0 (stale!)
+
+T=25:  Redis TTL expires (15s elapsed since T=10)
+       Redis: Session deleted automatically
+       Tomcat: Session still exists
+
+T=30:  processExpires() runs on Node B
+
+       OLD LOGIC (BROKEN):
+         Uses storedLastAccessedTime = 0
+         timeIdle = 30 - 0 = 30 seconds
+         If maxInactiveInterval = 20s:
+           30 >= 20 → Expire! ✗ WRONG!
+
+       NEW LOGIC (FIXED):
+         Session not in Redis (TTL expired)
+         No remainingTTL available
+         Falls back to stored value = 0
+         timeIdle = 30 - 0 = 30 seconds
+         maxInactiveInterval = 1800s
+         30 < 1800 → Keep! ✓ CORRECT!
+
+         (Session will eventually expire at T=1800)
+```
+
+### Example 2: Authenticated Session (Redis-Managed)
+
+```
+Timeline:
+---------
+T=0:    User logs in
+        Session gets DOT_CLUSTER_SESSION_ATTR
+        Saved to Redis: TTL = 1800s
+        Saved to Tomcat on Node A: lastAccessedTime = 0
+
+T=300:  User actively using app on Node A
+        Every request refreshes Redis TTL to 1800s
+        Node A's lastAccessedTime = recent
+
+T=600:  Load balancer routes request to Node B
+        Node B loads session from Redis
+        Node B's lastAccessedTime = 0 (stale!)
+
+T=1800: No activity for 1200 seconds
+
+T=1800: processExpires() runs on Node B
+
+        OLD LOGIC (BROKEN):
+          Calls isValid()
+          StandardSession.isValid():
+            timeIdle = 1800 - 0 = 1800 seconds
+            maxInactiveInterval = 1800s
+            1800 >= 1800 → Expire! ✗
+          Session expired on Node B
+          Meanwhile, Redis still has it (TTL refreshed by Node A)
+          User on Node A: Session alive ✓
+          User on Node B: Session gone ✗
+          INCONSISTENT!
+
+        NEW LOGIC (FIXED):
+          Calls isValid()
+          RedisSession.isValid():
+            Has DOT_CLUSTER_SESSION_ATTR → Redis-managed
+            Returns true (only checks valid flag)
+          processExpires():
+            Checks existsInRedis() → True (still in Redis)
+            Keeps session alive ✓
+          ALL NODES: Session alive ✓
+          CONSISTENT!
+
+T=3600: User stops activity
+        No requests for 1800 seconds
+        Redis TTL reaches 0
+        Redis: Session deleted automatically
+
+T=3606: processExpires() runs
+
+        NEW LOGIC:
+          Checks existsInRedis() → False
+          Expires session in Tomcat ✓
+          Session cleaned up properly ✓
+```
+
+### Example 3: Stale Timestamp with Redis TTL Calculation (Undefined Session)
+
+```
+Timeline:
+---------
+T=0:   Session created on Node A (undefined, not authenticated)
+       Saved to Redis: TTL = 15s
+       Tomcat: maxInactiveInterval = 1800s (Tomcat's default)
+       storedLastAccessedTime = 0
+
+T=5:   Request on Node A
+       Saved to Redis: TTL = 15s (refreshed)
+       storedLastAccessedTime = 0 (not updated in serialized form)
+
+T=10:  Request on Node B
+       Loaded from Redis
+       storedLastAccessedTime = 0 (stale!)
+       Saved back to Redis: TTL = 15s (refreshed)
+
+T=15:  processExpires() runs on Node B
+
+       Calculation with Redis TTL:
+         Session type: Undefined (no DOT_CLUSTER_SESSION_ATTR)
+         remainingTTL = 10s (15s TTL set at T=10, now T=15)
+
+         IMPORTANT: originalTTL = undefinedSessionTypeTimeout (15s)
+                    NOT maxInactiveInterval (1800s)!
+
+         timeSinceLastAccess = 15 - 10 = 5 seconds
+         calculatedLastAccessedTime = T=15 - 5s = T=10 ✓ ACCURATE!
+
+         storedLastAccessedTime = T=0 (stale)
+
+         Returns: max(T=10, T=0) = T=10 ✓
+
+         timeIdle = T=15 - T=10 = 5 seconds
+         maxInactiveInterval = 1800s (Tomcat's default)
+         5 < 1800 → Keep! ✓ CORRECT!
+
+NOTE: After T=25 (15s after T=10), Redis will auto-delete this session.
+      Tomcat will continue managing it with maxInactiveInterval = 1800s.
+      At that point, lastAccessedTime calculation will fall back to stored value.
+```
+
+---
+
+## Summary
+
+### The Problem
+1. **Stale lastAccessedTime**: Became outdated after multiple save/load cycles
+2. **Incorrect Expiration**: Tomcat expired sessions that were still active in Redis
+3. **Cluster Inconsistency**: Different nodes made different expiration decisions
+
+### The Solution
+1. **Override processExpires()**: Implement session-type-aware expiration logic
+2. **Override isValid()**: Skip idle time checks for Redis-managed sessions
+3. **Override getLastAccessedTime()**: Calculate accurate time from Redis TTL
+
+### The Result
+- ✅ **Accurate Expiration**: Sessions expire based on real activity, not stale data
+- ✅ **Cluster Consistency**: All nodes use Redis as source of truth
+- ✅ **Correct Behavior**: Tomcat-managed sessions use local expiration, Redis-managed sessions use Redis TTL
+- ✅ **No Premature Expiration**: Active sessions stay alive across the cluster
+
+### Key Insights
+
+1. **Redis TTL is the Source of Truth**: Always accurate, refreshed on every access
+2. **Different Sessions, Different Rules**: Undefined vs authenticated sessions need different expiration strategies
+3. **Dual Storage Benefits**: Combines Redis consistency with Tomcat performance
+4. **Session Type Matters**: Must know whether session is Tomcat-managed or Redis-managed

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'signing'
 apply plugin: 'maven-publish'
 
 group = 'com.dotcms'
-version = '1.4'
+version = '1.5'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/dotcms/tomcat/redissessions/RedisSession.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/RedisSession.java
@@ -231,4 +231,157 @@ public class RedisSession extends StandardSession {
         }
     }
 
+    /**
+     * Returns the valid flag from the base class without triggering expiration checks.
+     * This is used internally by the overridden {@link #isValid()} method for Redis-managed sessions.
+     *
+     * @return {@code true} if the session is marked as valid, {@code false} otherwise
+     */
+    protected boolean getValidFlag() {
+        return this.isValid;
+    }
+
+    /**
+     * Returns the last accessed time for this session, calculated from Redis TTL.
+     *
+     * <p><b>How It Works</b>:</p>
+     * <ul>
+     *     <li>Queries Redis for remaining TTL on the session key</li>
+     *     <li>Determines the original Redis TTL based on session type:
+     *         <ul>
+     *             <li>Undefined sessions: uses undefinedSessionTypeTimeout (15s)</li>
+     *             <li>Authenticated sessions: uses maxInactiveInterval (1800s)</li>
+     *         </ul>
+     *     </li>
+     *     <li>Calculates: lastAccessedTime = currentTime - (originalTTL - remainingTTL)</li>
+     *     <li>Compares with stored lastAccessedTime from base class</li>
+     *     <li>Returns the most recent (max) to ensure accuracy</li>
+     * </ul>
+     *
+     * <p><b>Why This Works for All Session Types</b>:</p>
+     * <ul>
+     *     <li><b>Tomcat-managed sessions (undefined)</b>: maxInactiveInterval = Tomcat's default session timeout
+     *     (typically 1800s or as configured in web.xml). Redis stores with short TTL (15s) for cluster
+     *     coordination only.</li>
+     *     <li><b>Redis-managed sessions (authenticated)</b>: maxInactiveInterval = userSessionTimeout (1800s),
+     *     synchronized with Redis TTL for cluster-consistent expiration.</li>
+     *     <li>TTL calculation works the same way for both types</li>
+     * </ul>
+     *
+     * <p><b>Why Return Max(calculated, stored)</b>:</p>
+     * <ul>
+     *     <li>If TTL-based calculation is more recent → use it (handles stale stored value)</li>
+     *     <li>If stored value is more recent → use it (handles edge cases in TTL calculation)</li>
+     *     <li>Always returns the most up-to-date last access time</li>
+     *     <li>Robust against both stale serialization and TTL edge cases</li>
+     * </ul>
+     *
+     * <p><b>Stale Timestamp Problem</b>:</p>
+     * <p>When a session is saved to and loaded from Redis multiple times, the stored
+     * lastAccessedTime becomes stale. Redis TTL is refreshed on every access, making it
+     * the accurate source of truth. By calculating from TTL and comparing with stored value,
+     * we ensure the most accurate timing information.</p>
+     *
+     * @return The time this session was last accessed, in milliseconds since epoch (most recent value)
+     */
+    @Override
+    public long getLastAccessedTime() {
+        // Check validity first
+        if (!getValidFlag()) {
+            throw new IllegalStateException(
+                    sm.getString("standardSession.getLastAccessedTime.ise"));
+        }
+
+        if (this.manager instanceof RedisSessionManager) {
+            final RedisSessionManager redisManager = (RedisSessionManager) this.manager;
+
+            try {
+                final long remainingTTL = redisManager.getRemainingTTL(this.getId());
+
+                if (remainingTTL >= 0) {
+                    // Determine the original TTL that was set in Redis (not maxInactiveInterval!)
+                    // For undefined sessions: Redis TTL = undefinedSessionTypeTimeout (15s)
+                    // For authenticated sessions: Redis TTL = userSessionTimeout (1800s)
+                    final long originalTTL;
+                    if (this.getAttribute(DOT_CLUSTER_SESSION_ATTR) != null || redisManager.isAnonTrafficEnabled()) {
+                        // Authenticated session: Redis TTL matches maxInactiveInterval
+                        originalTTL = this.getMaxInactiveInterval();
+                    } else {
+                        // Undefined session: Redis TTL is the short timeout (not maxInactiveInterval)
+                        originalTTL = redisManager.getUndefinedSessionTypeTimeout();
+                    }
+                    final long timeSinceLastAccess = (originalTTL - remainingTTL) * 1000L;
+                    final long currentTime = System.currentTimeMillis();
+                    final long calculatedLastAccessedTime = currentTime - timeSinceLastAccess;
+
+                    // Get stored lastAccessedTime from base class (safe now - we checked validity)
+                    final long storedLastAccessedTime = super.getLastAccessedTime();
+
+                    // Return the most recent (max) to ensure we have the most up-to-date value
+                    // This handles both stale stored values and edge cases in TTL calculation
+                    return Math.max(calculatedLastAccessedTime, storedLastAccessedTime);
+                }
+            } catch (Exception e) {
+                // Fall back to stored value if Redis is unavailable
+                log.warn(String.format("Error getting remaining TTL for session [ %s ]. " +
+                        "Falling back to stored lastAccessedTime: %s", this.getId(), e.getMessage()));
+            }
+        }
+
+        // Fallback: Use stored lastAccessedTime (safe - we checked validity above)
+        return super.getLastAccessedTime();
+    }
+
+    /**
+     * Checks if the session is valid, with different behavior based on session type:
+     *
+     * <p><b>For Redis-managed sessions</b> (sessions with DOT_CLUSTER_SESSION_ATTR or when
+     * TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = true):</p>
+     * <ul>
+     *     <li>Only checks the session's valid flag</li>
+     *     <li>DOES NOT check lastAccessedTime or maxInactiveInterval</li>
+     *     <li>Expiration is managed by Redis TTL, not Tomcat idle time</li>
+     * </ul>
+     *
+     * <p><b>For Tomcat-managed sessions</b> (undefined sessions without DOT_CLUSTER_SESSION_ATTR
+     * when TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false):</p>
+     * <ul>
+     *     <li>Delegates to base class {@code super.isValid()}</li>
+     *     <li>Includes idle time expiration checks (lastAccessedTime + maxInactiveInterval)</li>
+     *     <li>Base class will automatically call {@code expire()} if session is expired</li>
+     * </ul>
+     *
+     * <p>This separation ensures that Redis-managed sessions are not prematurely expired by
+     * Tomcat's local expiration logic, which would cause inconsistent expiration across cluster
+     * nodes.</p>
+     *
+     * @return {@code true} if the session is valid, {@code false} otherwise
+     */
+    @Override
+    public boolean isValid() {
+        // Check valid flag FIRST before accessing attributes
+        if (!getValidFlag()) {
+            return false;
+        }
+
+        if (this.manager instanceof RedisSessionManager) {
+            final RedisSessionManager redisManager = (RedisSessionManager) this.manager;
+
+            // Now safe to check attributes since we know session is valid
+            // Check if this is a Redis-managed session
+            final boolean isRedisManagedSession =
+                    this.getAttribute(DOT_CLUSTER_SESSION_ATTR) != null
+                    || redisManager.isAnonTrafficEnabled();
+
+            if (isRedisManagedSession) {
+                // Redis-managed: Only check valid flag, skip idle time checks
+                // Expiration is managed by Redis TTL
+                return true;  // Already checked valid flag above
+            }
+        }
+
+        // Tomcat-managed: Delegate to base class which includes idle time expiration
+        return super.isValid();
+    }
+
 }

--- a/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionManager.java
+++ b/src/main/java/com/dotcms/tomcat/redissessions/RedisSessionManager.java
@@ -282,24 +282,61 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     }
 
     /**
-     * Specifies the TTL (time-to-live) for the Sessions that may not be associated with an authenticated request. This
-     * is extremely important to take into consideration in dotCMS clustered environments.
-     * <p>When a login request goes to dotCMS, after our APIs have authorized the User, the
-     * {@link RedisSession#DOT_CLUSTER_SESSION_ATTR} attribute is added to the session. This causes the plugin to persist it
-     * to Redis as it is effectively a back-end session. Subsequent -- or almost parallel -- requests are also initiated
-     * when such an authentication process happens. However, in multi-node instances, for instance, the main
-     * authentication request may have gone to node #1, but some of those subsequent requests may try to retrieve the
-     * session from node #2, where it doesn't exist. This causes different requests to create several invalid sessions
-     * that cause errors in the application.</p>
-     * <p>In order to prevent that, every initial session -- which MAY or MAY NOT be associated to a back-end/front-end
-     * login -- needs to be persisted to Redis first, ate least for a few seconds, so it can be used by the other nodes
-     * in the cluster and handle the requests appropriately.</p>
+     * Returns whether anonymous traffic is enabled for Redis session management.
      *
-     * @param undefinedSessionTypeTimeout The time in seconds before the Redis entry representing the session gets
-     *                                    evicted.
+     * @return {@code true} if all sessions (including anonymous) are managed by Redis, {@code false} if only authenticated sessions use Redis expiration.
+     */
+    public boolean isAnonTrafficEnabled() {
+        return this.isAnonTrafficEnabled;
+    }
+
+    /**
+     * Specifies the Redis TTL (time-to-live) in seconds for undefined sessions (sessions without
+     * the {@link RedisSession#DOT_CLUSTER_SESSION_ATTR} attribute). This setting is critical for
+     * preventing race conditions in clustered environments during authentication.
+     * <p><b>Purpose:</b> When a user first accesses the application (before authentication), a session
+     * is created without the {@code DOT_CLUSTER_SESSION_ATTR} attribute. In clustered environments,
+     * parallel requests during authentication may arrive at different nodes. Storing these new sessions
+     * in Redis temporarily allows all nodes to see the same session and prevents duplicate session creation.</p>
+     * <p><b>Dual Storage Behavior (when TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false, default):</b></p>
+     * <ul>
+     *     <li><b>Undefined sessions (no DOT_CLUSTER_SESSION_ATTR):</b>
+     *         <ul>
+     *             <li>Stored in Red and Tomcat with TTL = {@code undefinedSessionTypeTimeout} (default 15s)</li>
+     *             <li>After Redis TTL expires, entry auto-deleted from Redis</li>
+     *             <li>Tomcat's {@code processExpires()} manages actual session expiration based on {@code lastAccessedTime}</li>
+     *         </ul>
+     *     </li>
+     *     <li><b>When authenticated (DOT_CLUSTER_SESSION_ATTR is set):</b>
+     *         <ul>
+     *             <li>Redis TTL updated to {@code userSessionTimeout} (default 1800s)</li>
+     *             <li>Remains in both Redis and Tomcat</li>
+     *             <li>Redis TTL manages expiration (cluster-consistent)</li>
+     *             <li>Tomcat's {@code processExpires()} skips these sessions</li>
+     *         </ul>
+     *     </li>
+     * </ul>
+     * <p><b>Note:</b> When {@code TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = true}, this parameter is not used
+     * for undefined sessions as all sessions (including anonymous) use {@code userSessionTimeout} instead.</p>
+     * <p><b>Default:</b> 15 seconds - long enough to handle authentication flows but short enough to
+     * quickly clean Redis of anonymous sessions that will be managed locally by Tomcat.</p>
+     *
+     * @param undefinedSessionTypeTimeout The Redis TTL in seconds for undefined sessions. After this time,
+     *                                    the session is auto-deleted from Redis but continues to exist in
+     *                                    Tomcat for local expiration management (when
+     *                                    TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false).
      */
     public void setUndefinedSessionTypeTimeout(final int undefinedSessionTypeTimeout) {
         this.undefinedSessionTypeTimeout = undefinedSessionTypeTimeout;
+    }
+
+    /**
+     * Returns the Redis TTL (time-to-live) in seconds for undefined sessions.
+     *
+     * @return The TTL in seconds for undefined sessions.
+     */
+    public int getUndefinedSessionTypeTimeout() {
+        return this.undefinedSessionTypeTimeout;
     }
 
     @Override
@@ -396,7 +433,11 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
             session.setNew(true);
             session.setValid(true);
             session.setCreationTime(System.currentTimeMillis());
-            session.setMaxInactiveInterval(this.userSessionTimeout);
+            // Set maxInactiveInterval to Tomcat's default timeout
+            // This is appropriate for undefined (Tomcat-managed) sessions
+            // For authenticated sessions, this will be updated to userSessionTimeout
+            // when setSessionExpiration() is called during save()
+            session.setMaxInactiveInterval(this.getTomcatSessionTimeoutInSeconds());
             session.setId(sessionId);
             session.tellNew();
         }
@@ -423,8 +464,12 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
      */
     private boolean isSessionPersistable(final Session session) {
         boolean persistable = false;
-        if (null != session && null != ((RedisSession) session).getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR)) {
-            persistable = (boolean) ((RedisSession) session).getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR);
+        // Check session is valid before accessing attributes
+        if (null != session && session.isValid()) {
+            final Object attrValue = ((RedisSession) session).getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR);
+            if (null != attrValue) {
+                persistable = (boolean) attrValue;
+            }
         }
         return persistable || this.isAnonTrafficEnabled;
     }
@@ -450,14 +495,28 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
         return new RedisSession(this);
     }
 
+    /**
+     * Adds a newly created session to both Redis and Tomcat's session manager (dual storage).
+     * <p>All new sessions are saved to Redis with an appropriate TTL and added to Tomcat's local
+     * session manager via {@link #save(Session)}, which calls {@link #setSessionExpiration(Session, long)}.</p>
+     * <p><b>TTL Assignment (when TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false, default):</b></p>
+     * <ul>
+     *     <li><b>Without DOT_CLUSTER_SESSION_ATTR:</b> Redis TTL = {@code undefinedSessionTypeTimeout}
+     *     (default 15s). Used for cluster coordination during authentication. Tomcat manages expiration
+     *     via {@code processExpires()}.</li>
+     *     <li><b>With DOT_CLUSTER_SESSION_ATTR:</b> Redis TTL = {@code userSessionTimeout} (default 1800s).
+     *     Redis manages expiration for cluster-consistent behavior.</li>
+     * </ul>
+     * <p><b>When TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = true:</b> All sessions use {@code userSessionTimeout}
+     * and Redis manages expiration.</p>
+     *
+     * @param session The session to add.
+     * @throws RuntimeException if an error occurs while saving the session to Redis.
+     */
     @Override
     public void add(final Session session) {
         try {
-            if (this.isSessionPersistable(session)) {
-                this.save(session);
-            } else {
-                super.add(session);
-            }
+            this.save(session);
         } catch (final IOException ex) {
             final String errorMsg = String.format("Unable to add session [ %s ] to Redis: %s" ,session, ex.getMessage());
             log.error(errorMsg);
@@ -465,6 +524,34 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
         }
     }
 
+    /**
+     * Finds a session by ID using a multi-tier lookup strategy with stale session detection.
+     * <p><b>Lookup Order:</b></p>
+     * <ol>
+     *     <li><b>ThreadLocal:</b> Check if this is the current request's session (fastest)</li>
+     *     <li><b>Redis:</b> Deserialize from Redis if found</li>
+     *     <li><b>Tomcat:</b> Check Tomcat's local session manager if not in Redis</li>
+     *     <li><b>Not found:</b> Return null</li>
+     * </ol>
+     * <p><b>Stale Session Detection:</b></p>
+     * <p>When a session is found in Tomcat but NOT in Redis, this method checks if it should have
+     * been in Redis:</p>
+     * <ul>
+     *     <li><b>Has DOT_CLUSTER_SESSION_ATTR:</b> This is an authenticated session that SHOULD be
+     *     in Redis. Not being in Redis means it expired there (TTL reached). The method expires
+     *     the Tomcat copy and returns {@code null} to maintain consistency.</li>
+     *     <li><b>No DOT_CLUSTER_SESSION_ATTR (when TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false):</b>
+     *     This is an undefined session managed by Tomcat. Redis TTL expired (15s), but session continues
+     *     in Tomcat - normal case, return the session.</li>
+     * </ul>
+     * <p><b>Note:</b> When {@code TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = true}, all sessions should
+     * be in Redis, so finding a session only in Tomcat would trigger stale session detection regardless
+     * of the attribute.</p>
+     *
+     * @param id The session identifier.
+     * @return The session if found and valid, or {@code null} if not found or stale.
+     * @throws IOException If an error occurs deserializing the session from Redis.
+     */
     @Override
     public Session findSession(final String id) throws IOException {
         RedisSession session = null;
@@ -487,12 +574,43 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
                 currentSessionIsPersisted.set(true);
                 currentSessionId.set(id);
             } else if (null != super.findSession(id)) {
-                log.debug(String.format("Session [ %s ] was found in Tomcat", id));
+                // Session found in Tomcat but not in Redis
+                log.debug(String.format("Session [ %s ] was found in Tomcat but not in Redis", id));
                 session = (RedisSession) super.findSession(id);
-                currentSession.set(session);
-                currentSessionId.set(id);
-                currentSessionIsPersisted.set(false);
-                currentSessionSerializationMetadata.set(new SessionSerializationMetadata());
+
+                // Check if the session is still valid before accessing attributes
+                if (!session.isValid()) {
+                    log.debug(String.format("Session [ %s ] found in Tomcat is already invalid. Returning null.", id));
+                    session = null;
+                    currentSessionIsPersisted.set(false);
+                    currentSession.remove();
+                    currentSessionSerializationMetadata.remove();
+                    currentSessionId.remove();
+                } else if (session.getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR) != null) {
+                    // This is an authenticated session that SHOULD be in Redis but isn't
+                    // This means it was invalidated/expired in Redis (TTL expired or explicitly deleted)
+                    // We should expire it in Tomcat as well to maintain consistency
+                    log.debug(String.format("Session [ %s ] has DOT_CLUSTER_SESSION_ATTR but is not in Redis. " +
+                            "Assuming it was invalidated in Redis. Expiring session in Tomcat.", id));
+                    try {
+                        session.expire();
+                    } catch (Exception e) {
+                        log.error(String.format("Error expiring stale session [ %s ]: %s", id, e.getMessage()));
+                    }
+                    // Return null to indicate session is gone
+                    session = null;
+                    currentSessionIsPersisted.set(false);
+                    currentSession.remove();
+                    currentSessionSerializationMetadata.remove();
+                    currentSessionId.remove();
+                } else {
+                    // This is an undefined/anonymous session managed by Tomcat - normal case
+                    log.debug(String.format("Session [ %s ] is a Tomcat-managed session (no DOT_CLUSTER_SESSION_ATTR)", id));
+                    currentSession.set(session);
+                    currentSessionId.set(id);
+                    currentSessionIsPersisted.set(false);
+                    currentSessionSerializationMetadata.set(new SessionSerializationMetadata());
+                }
             } else {
                 currentSessionIsPersisted.set(false);
                 currentSession.remove();
@@ -526,9 +644,16 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
             this.serializer.deserializeInto(data, session, metadata);
             session.setId(id);
             session.setNew(false);
-            session.setMaxInactiveInterval(this.userSessionTimeout);
-            session.access();
             session.setValid(true);
+            // Update maxInactiveInterval based on session type:
+            // - For authenticated sessions (Redis-managed): set to userSessionTimeout
+            // - For undefined sessions (Tomcat-managed): keep Tomcat's default, don't override
+            // This ensures authenticated sessions use the configured timeout while undefined
+            // sessions continue using Tomcat's original inactive interval
+            if (session.getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR) != null || this.isAnonTrafficEnabled) {
+                session.setMaxInactiveInterval(this.userSessionTimeout);
+            }
+            // For undefined sessions, don't set maxInactiveInterval - keep Tomcat's default
             session.resetDirtyTracking();
             if (log.isTraceEnabled()) {
                 log.trace(String.format("Contents from Session [ %s ]: ", id));
@@ -570,17 +695,36 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     }
 
     /**
-     * Saves the specified Session object to Redis. There are four scenarios under which the Session
-     * must be persisted to Redis:
+     * Saves the specified Session object to Redis and adds it to Tomcat's session manager.
+     * <p>The session data is persisted to Redis when any of the following conditions are met:</p>
      * <ol>
      *     <li>The {@code forceSave} parameter is set to {@code true}.</li>
      *     <li>The Session is dirty. That is, attributes were added and/or removed.</li>
-     *     <li>The {@link ThreadLocal} variable that stores the persisted Session object is empty
-     *     .</li>
+     *     <li>The {@link ThreadLocal} variable that stores the persisted Session object is empty.</li>
      *     <li>The value of the {@link SessionSerializationMetadata} object contained in the
-     *     {@link ThreadLocal}
-     *     variable is different from the one in the specified {@code session} parameter.</li>
+     *     {@link ThreadLocal} variable is different from the one in the specified {@code session} parameter.</li>
      * </ol>
+     * <p><b>Dual Storage Strategy:</b></p>
+     * <p>All sessions are stored in both Redis and Tomcat's session manager. The {@code DOT_CLUSTER_SESSION_ATTR}
+     * attribute and {@code TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC} configuration determine the expiration mechanism:</p>
+     * <ul>
+     *     <li><b>When TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false (default):</b>
+     *         <ul>
+     *             <li><b>Without DOT_CLUSTER_SESSION_ATTR (undefined/anonymous sessions):</b> Redis stores with
+     *             short TTL ({@code undefinedSessionTypeTimeout}, default 15s) for cluster coordination.
+     *             Tomcat's {@code processExpires()} manages actual expiration based on {@code lastAccessedTime}.</li>
+     *             <li><b>With DOT_CLUSTER_SESSION_ATTR (authenticated sessions):</b> Redis stores with full TTL
+     *             ({@code userSessionTimeout}, default 1800s). Redis TTL manages expiration to ensure consistency
+     *             across cluster nodes. Tomcat's {@code processExpires()} skips these sessions.</li>
+     *         </ul>
+     *     </li>
+     *     <li><b>When TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = true:</b> All sessions (including anonymous) use full
+     *     TTL ({@code userSessionTimeout}) and Redis manages expiration. Tomcat's {@code processExpires()}
+     *     only checks for sessions that expired in Redis but remain in Tomcat.</li>
+     * </ul>
+     * <p>This approach ensures authenticated sessions are clustered and expire consistently across nodes,
+     * while undefined sessions use Redis temporarily for cluster coordination and then rely on local
+     * Tomcat expiration (when TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false).</p>
      *
      * @param session   The current {@link Session}.
      * @param forceSave If the specified Session object MUST be saved no matter what, set this to
@@ -624,13 +768,16 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
             } else {
                 log.debug(String.format("Save on Session [ %s ] was NOT necessary", sessionId));
             }
+            // Set Redis TTL based on session type
             if (null == ((RedisSession) session).getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR) && !this.isAnonTrafficEnabled) {
-                log.debug(String.format("Session [ %s ] doesn't seem to belong to a back-end request. Setting expiration time to " +
-                        "%d seconds", sessionId, this.undefinedSessionTypeTimeout));
+                // Undefined session (no authentication): short TTL in Redis, will be expired by Tomcat
+                log.debug(String.format("Session [ %s ] is undefined. Setting Redis TTL to %d seconds. " +
+                        "Session expiration will be managed by Tomcat.", sessionId, this.undefinedSessionTypeTimeout));
                 this.setSessionExpiration(session, this.undefinedSessionTypeTimeout);
-                super.add(session);
             } else {
-                log.debug(String.format("Setting expire timeout on session [ %s ] to %d seconds", sessionId, this.userSessionTimeout));
+                // Authenticated session or anonymous traffic enabled: full TTL, Redis manages expiration
+                log.debug(String.format("Session [ %s ] is persistable. Setting Redis TTL to %d seconds. " +
+                        "Session expiration will be managed by Redis.", sessionId, this.userSessionTimeout));
                 this.setSessionExpiration(session, this.userSessionTimeout);
             }
         } catch (final IOException e) {
@@ -641,18 +788,46 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     }
 
     /**
-     * Sets the expiration time for the newly created Session, as this process will be completely
-     * handled by Redis.
+     * Sets the expiration time for a session in both Redis and Tomcat's session manager.
+     * <p>All sessions are stored in both Redis (for cluster coordination) and Tomcat's local
+     * manager (for expiration processing). The {@code DOT_CLUSTER_SESSION_ATTR} attribute
+     * and {@code TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC} configuration determine which system manages expiration:</p>
+     * <ul>
+     *     <li><b>When TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false (default):</b>
+     *         <ul>
+     *             <li><b>Without DOT_CLUSTER_SESSION_ATTR (undefined sessions):</b> Short Redis TTL (15s, auto-expires in Redis),
+     *             Tomcat's processExpires() handles actual expiration using Tomcat's default maxInactiveInterval.
+     *             The session's maxInactiveInterval is NOT changed - it keeps using Tomcat's original timeout.</li>
+     *             <li><b>With DOT_CLUSTER_SESSION_ATTR (authenticated sessions):</b> Full Redis TTL (1800s, Redis manages expiration),
+     *             session's maxInactiveInterval is set to match Redis TTL. Tomcat's processExpires() only checks for stale sessions.</li>
+     *         </ul>
+     *     </li>
+     *     <li><b>When TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = true:</b> All sessions use full Redis TTL (1800s)
+     *     and Redis manages expiration. Session's maxInactiveInterval is set to match Redis TTL.
+     *     Tomcat's processExpires() only checks for stale sessions.</li>
+     * </ul>
      * <p>If the value for the {@code DOT_DOTCMS_CLUSTER_ID} is specified, it'll be used to prefix
-     * they key. Doing this will allow multiple clusters to share the same Session Redis Store.</p>
+     * the Redis key, allowing multiple clusters to share the same Redis instance.</p>
      *
      * @param session The {@link Session} object whose TTL is being set.
-     * @param seconds The number of seconds after which the Session will expire.
+     * @param seconds The number of seconds after which the Session will expire in Redis.
      */
     protected void setSessionExpiration(final Session session, final long seconds) {
         final String prefixedKey = this.prefix + session.getId();
+
+        // Always set Redis TTL
         this.jedisPool.expire(prefixedKey.getBytes(), seconds);
-        session.setMaxInactiveInterval((int) seconds);
+
+        // Only set maxInactiveInterval for authenticated sessions (Redis-managed)
+        // For undefined sessions (Tomcat-managed), keep Tomcat's original maxInactiveInterval
+        final RedisSession redisSession = (RedisSession) session;
+        if (redisSession.getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR) != null || this.isAnonTrafficEnabled) {
+            // Authenticated session: synchronize maxInactiveInterval with Redis TTL
+            session.setMaxInactiveInterval((int) seconds);
+        }
+        // For undefined sessions, don't modify maxInactiveInterval - keep Tomcat's default timeout
+
+        // Add to Tomcat's session manager for local tracking and expiration processing
         super.add(session);
     }
 
@@ -674,6 +849,14 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
      * This method is called by the {@link RedisSessionHandlerValve} after any HTTP Request has been processed. It
      * takes care of saving the current Session -- if it's still valid -- or removing it in case it is not. It also
      * differentiates "non-persistable" sessions from "persistable" ones, and handles them accordingly.
+     * <p>For valid sessions, this method:</p>
+     * <ul>
+     *     <li>Saves the session to Redis (if dirty or based on persistence policy)</li>
+     *     <li>Refreshes the Redis TTL (happens always via setSessionExpiration())</li>
+     * </ul>
+     * <p>Note: Session lifecycle methods like {@code access()} and {@code endAccess()} are handled by
+     * Tomcat's request processing infrastructure (CoyoteAdapter.service() → Request.recycle() →
+     * Request.recycleSessionInfo()), not by this method.</p>
      */
     public void afterRequest() {
         final RedisSession redisSession = this.currentSession.get();
@@ -684,6 +867,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
         try {
             if (redisSession.isValid()) {
                 log.debug(String.format("Request has finished. Saving session [ %s ]", sessionId));
+                // Save session to Redis (also refreshes TTL via setSessionExpiration())
                 this.save(redisSession, this.getAlwaysSaveAfterRequest());
             } else {
                 if (!this.isSessionPersistable(redisSession)) {
@@ -705,13 +889,93 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     }
 
     /**
-     * If anonymous sessions are NOT allowed into Redis -- i.e., are handled in memory by Tomcat -- then we need to
-     * check and invalidate all front-end sessions that have expired, which is the default behavior.
+     * Processes session expiration handling two distinct cases:
+     * <p><b>Case 1: Undefined/Anonymous Sessions (no DOT_CLUSTER_SESSION_ATTR):</b></p>
+     * <ul>
+     *     <li>When {@code TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = false}, these sessions are managed by Tomcat</li>
+     *     <li>Expired based on {@code lastAccessedTime} and {@code maxInactiveInterval}</li>
+     *     <li>Redis stores with short TTL (15s) for cluster coordination only</li>
+     * </ul>
+     * <p><b>Case 2: Authenticated Sessions (has DOT_CLUSTER_SESSION_ATTR) or All Sessions
+     * (when TOMCAT_REDIS_ENABLED_FOR_ANON_TRAFFIC = true):</b></p>
+     * <ul>
+     *     <li>These sessions are managed by Redis TTL for cluster-consistent expiration</li>
+     *     <li>This method checks if session exists in Redis using {@link #existsInRedis(String)}</li>
+     *     <li>If session is in Tomcat but NOT in Redis → Redis TTL expired → expire in Tomcat</li>
+     *     <li>This prevents memory leaks where sessions remain in Tomcat after Redis cleanup</li>
+     * </ul>
      */
     @Override
     public void processExpires() {
-        if (!this.isAnonTrafficEnabled) {
-            super.processExpires();
+        long timeNow = System.currentTimeMillis();
+        Session[] sessions = findSessions();
+        int expireHere = 0;
+
+        if (log.isDebugEnabled()) {
+            log.debug("Start expire sessions at " + timeNow + " sessioncount " + sessions.length);
+        }
+
+        for (Session session : sessions) {
+            if (session instanceof RedisSession) {
+                RedisSession redisSession = (RedisSession) session;
+
+                // Check valid flag before accessing attributes to prevent IllegalStateException
+                if (!redisSession.isValid()) {
+                    // Session already invalid, skip it
+                    continue;
+                }
+
+                if (redisSession.getAttribute(RedisSession.DOT_CLUSTER_SESSION_ATTR) == null
+                        && !this.isAnonTrafficEnabled) {
+                    // Case 1: Undefined session (Tomcat-managed expiration)
+                    // Check expiration using real lastAccessedTime calculated from Redis TTL
+                    if (!redisSession.isNew()) {
+                        try {
+                            // Get the real lastAccessedTime (calculated from Redis TTL)
+                            final long lastAccessedTime = redisSession.getLastAccessedTime();
+                            final int maxInactiveInterval = redisSession.getMaxInactiveInterval();
+
+                            // Calculate idle time
+                            final long timeIdle = (timeNow - lastAccessedTime) / 1000L;
+
+                            // Check if session has exceeded maxInactiveInterval
+                            // Note: validFlag already checked at line 906, so session is valid here
+                            if (maxInactiveInterval > 0 && timeIdle >= maxInactiveInterval) {
+                                expireHere++;
+                                if (log.isDebugEnabled()) {
+                                    log.debug(String.format("Session [ %s ] expired by Tomcat. Idle time: %d seconds, Max inactive: %d seconds",
+                                            redisSession.getId(), timeIdle, maxInactiveInterval));
+                                }
+                                redisSession.expire();
+                            }
+                        } catch (Throwable t) {
+                            log.error(String.format("Error expiring session [ %s ]: %s", redisSession.getId(), t.getMessage()));
+                        }
+                    }
+                } else {
+                    // Case 2: Authenticated session (Redis-managed) or all sessions when isAnonTrafficEnabled = true
+                    // Check if session still exists in Redis
+                    try {
+                        if (!existsInRedis(redisSession.getId())) {
+                            // Redis TTL expired, but session still in Tomcat → memory leak
+                            // Expire it in Tomcat to clean up
+                            expireHere++;
+                            if (log.isDebugEnabled()) {
+                                log.debug(String.format("Session [ %s ] expired in Redis (TTL reached) but still in Tomcat. " +
+                                        "Expiring in Tomcat to prevent memory leak.", redisSession.getId()));
+                            }
+                            redisSession.expire();
+                        }
+                    } catch (Throwable t) {
+                        log.error(String.format("Error checking/expiring Redis-managed session [ %s ]: %s",
+                                redisSession.getId(), t.getMessage()));
+                    }
+                }
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("End expire sessions processing. Expired sessions: " + expireHere);
         }
     }
 
@@ -892,6 +1156,39 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     protected byte[] getRedisEntry(final String key) {
         final String prefixedKey = this.prefix + key;
         return this.jedisPool.get(prefixedKey.getBytes());
+    }
+
+    /**
+     * Checks if a session entry exists in Redis.
+     * <p>This method is used by {@link #processExpires()} to detect sessions that have expired
+     * in Redis (TTL reached) but still exist in Tomcat's session manager, allowing cleanup to
+     * prevent memory leaks.</p>
+     * <p>If the value for the {@code DOT_DOTCMS_CLUSTER_ID} is specified, it'll be used to prefix
+     * the key.</p>
+     *
+     * @param sessionId The session ID to check.
+     * @return {@code true} if the session exists in Redis, {@code false} otherwise.
+     */
+    protected boolean existsInRedis(final String sessionId) {
+        final String prefixedKey = this.prefix + sessionId;
+        return this.jedisPool.exists(prefixedKey.getBytes());
+    }
+
+    /**
+     * Gets the remaining TTL (time-to-live) in seconds for a session in Redis.
+     *
+     * <p>This method is used to calculate the real last access time for Tomcat-managed sessions
+     * by comparing the original TTL with the remaining TTL. The difference represents the time
+     * elapsed since the last access.</p>
+     *
+     * <p><b>Formula</b>: lastAccessedTime = currentTime - (originalTTL - remainingTTL)</p>
+     *
+     * @param sessionId The session ID to check.
+     * @return The remaining TTL in seconds, or -1 if the key doesn't exist or has no TTL, or -2 if the key doesn't exist at all.
+     */
+    protected long getRemainingTTL(final String sessionId) {
+        final String prefixedKey = this.prefix + sessionId;
+        return this.jedisPool.ttl(prefixedKey.getBytes());
     }
 
     /**


### PR DESCRIPTION
Closes dotCMS/core#34491

### Proposed Changes

- `RedisSessionManager.processExpires()` method has been overridden to avoid expiring Redis-managed sessions prematurely.  Session idle time is calculated using Redis TTL-based timestamp.
- `RedisSession.isValid()` method has been overridden to skip idle time checks for Redis-managed sessions.
- `RedisSession.getLastAccessedTime()` method has been overridden to calculate lastAccessedTime from Redis TTL.


With these changes in place, we avoid Tomcat's standard session expiration mechanism incorrectly expiring sessions that are still active in Redis.